### PR TITLE
Addition to your #53 PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,21 +50,39 @@ For manual full text descriptions for the parts of your API you need to describe
 In the general part you can describe your API in general, authorizers, models and resources.
 If you want to find out more about models, you can skip to the next section.
 
+------
+#### Gotcha with 'version' and 'title' on the API
+
+Currently (August 2017) you'll have trouble with the `title` and `version` fields for you API description. If you define them as below, they'll be correctly created in API Gateway (you can see it in the web console) but when you export the Swagger document from API Gateway, your title and version will be ignored and replaced with something like:
+
+    version: "2017-08-23T07:59:29Z"
+    title: dev-your-api-serverless
+
+------
 Your general documentation has to be nested in the custom variables section and looks like this:
 
 ```YAML
 custom:
   documentation:
-    version: '1'
-    summary: 'My API'
-    description: 'This is my API'
+    info:
+      version: "2" # see note above about this being ignored
+      title: "Name of your API" # see note above about this being ignored
+      description: "This is the best API ever"
+      termsOfService: "http://www.example.com/terms-of-service"
+      contact:
+        name: "John Smith"
+        url: "http://www.example.com/me"
+        email: "js@example.com"
+      license:
+        name: "Licensing"
+        url: "http://www.example.com/licensing"
     tags:
       -
-        name: 'Data Creation'
-        description: 'Services to create things'
+        name: "Data Creation"
+        description: "Services to create things"
       -
-        name: 'Some other tag'
-        description: 'A tag for other things'
+        name: "Some other tag"
+        description: "A tag for other things"
     authorizers:
       -
         name: "MyCustomAuthorizer"
@@ -79,14 +97,15 @@ custom:
 ```
 
 Your documentation has to be nested in the `documentation` custom variable. You describe your
-documentation parts with the `description` and `summary` properties. The summary is some sort of
-title and the description is for further explanation.
+documentation parts with the `description` and `summary` (or `title` for the API itself) properties. The summary is some sort of
+title and the description is for further explanation. You can see the expected format in the [Swagger v2 specification for the info object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#info-object).
 
-On the upper level (directly in the `documentation` section) you describe your API in general.
+On the upper level, under the `documentation` section, you describe your API in the `info` object.
 In there you also can manually describe the version (needs to be a string). If you don't define the
 version, the version that API Gateway needs will automatically be generated. This auto version is a
 hash of the documentation you defined, so if you don't change your documentation, the documentation
 in API Gateway won't be touched.
+
 Underneath you can define `tags`, `authorizers`, `resources` and `models` which are all lists of descriptions.
 In addition to the description and the summary, Authorizers need the name of the authorizer, resources
 need the path of the described resource and models need the name of the model. Tags provides the description for tags that are used on `METHOD`s (HTTP events), [more info here](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#tag-object).

--- a/src/documentation.spec.js
+++ b/src/documentation.spec.js
@@ -15,8 +15,21 @@ describe('ServerlessAWSDocumentation', function () {
         locationProps: []
       }
       let def = {
-        description: 'the desc',
-        summary: 'the summary',
+        info: {
+          title: 'the title',
+          description: 'the desc',
+          version: 123,
+          termsOfService: 'http://www.example.com/terms-of-service',
+          contact: {
+            name: 'John Smith',
+            url: 'http://www.example.com/me',
+            email: 'js@example.com'
+          },
+          license: {
+            name: 'Licensing',
+            url: 'http://www.example.com/licensing'
+          }
+        },
         tags: ['tag1']
       }
       let knownLocation = {}
@@ -29,8 +42,21 @@ describe('ServerlessAWSDocumentation', function () {
             type: 'API'
           },
           properties: {
-            description: 'the desc',
-            summary: 'the summary',
+            info: {
+              title: 'the title',
+              description: 'the desc',
+              version: 123,
+              termsOfService: 'http://www.example.com/terms-of-service',
+              contact: {
+                name: 'John Smith',
+                url: 'http://www.example.com/me',
+                email: 'js@example.com'
+              },
+              license: {
+                name: 'Licensing',
+                url: 'http://www.example.com/licensing'
+              }
+            },
             tags: ['tag1']
           },
           restApiId: 'testApiId'


### PR DESCRIPTION
I'm not quite sure if I've done the right thing here, but I intend this to be added to your existing pull request: https://github.com/9cookies/serverless-aws-documentation/pull/53. Hopefully this PR gets accepted before your PR to the 9cookies repo so they can both go in at the same time.

I've added a test to support your fix for #37 and updated the README to better describe the expected YAML properties.